### PR TITLE
[ADDITION] Allow for the Chart Colors list to be reset

### DIFF
--- a/src/LiveChartsCore.Behaviours/LiveChartsCore.Behaviours.csproj
+++ b/src/LiveChartsCore.Behaviours/LiveChartsCore.Behaviours.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst;
-      net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst
+      net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst
     </TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">
       $(TargetFrameworks);net6.0-windows10.0.19041;net7.0-windows10.0.19041

--- a/src/LiveChartsCore/CartesianChart.cs
+++ b/src/LiveChartsCore/CartesianChart.cs
@@ -460,6 +460,10 @@ public class CartesianChart<TDrawingContext> : Chart<TDrawingContext>
         // get seriesBounds
         SetDrawMargin(ControlSize, new Margin());
 
+        if (_chartView.ResetSeries)
+        {
+            _nextSeries = 0;
+        }
         foreach (var series in VisibleSeries.Cast<ICartesianSeries<TDrawingContext>>())
         {
             if (series.SeriesId == -1) series.SeriesId = _nextSeries++;

--- a/src/LiveChartsCore/Kernel/Sketches/IChartView.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/IChartView.cs
@@ -36,6 +36,11 @@ namespace LiveChartsCore.Kernel.Sketches;
 public interface IChartView
 {
     /// <summary>
+    /// Gets or sets the ability to stop the chart colors from resetting.
+    /// </summary>
+    bool ResetSeries { get; set; }
+
+    /// <summary>
     /// Gets the core.
     /// </summary>
     /// <value>
@@ -65,7 +70,7 @@ public interface IChartView
     LvcSize ControlSize { get; }
 
     /// <summary>
-    /// Gets or sets the draw margin, if this property is null, the library will calculate a margin, this margin is the distance 
+    /// Gets or sets the draw margin, if this property is null, the library will calculate a margin, this margin is the distance
     /// between the view bounds and the drawable area.
     /// </summary>
     /// <value>
@@ -82,7 +87,7 @@ public interface IChartView
     TimeSpan AnimationsSpeed { get; set; }
 
     /// <summary>
-    /// Gets or sets the easing function, the library already provides many easing functions in the 
+    /// Gets or sets the easing function, the library already provides many easing functions in the
     /// LiveCharts.EasingFunction static class.
     /// </summary>
     /// <value>

--- a/src/LiveChartsCore/LiveChartsCore.csproj
+++ b/src/LiveChartsCore/LiveChartsCore.csproj
@@ -4,14 +4,14 @@
     <Nullable>enable</Nullable>
     <LangVersion>11.0</LangVersion>
 
-    <TargetFrameworks>netstandard2.0;netcoreapp2.0;net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">
       $(TargetFrameworks);net6.0-windows10.0.19041;net462
     </TargetFrameworks>
 
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-ios'">14.2</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net8.0-ios'">14.2</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net8.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net8.0-android'">21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</TargetPlatformMinVersion>
 

--- a/src/LiveChartsCore/PieChart.cs
+++ b/src/LiveChartsCore/PieChart.cs
@@ -165,6 +165,12 @@ public class PieChart<TDrawingContext> : Chart<TDrawingContext>
         IndexBounds = new Bounds();
         PushoutBounds = new Bounds();
 
+        if (_chartView.ResetSeries)
+        {
+            _nextSeries = 0;
+            _drawnSeries.Clear();
+        }
+
         foreach (var series in VisibleSeries.Cast<IPieSeries<TDrawingContext>>())
         {
             if (series.SeriesId == -1) series.SeriesId = _nextSeries++;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/LiveChartsCore.SkiaSharpView.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/LiveChartsCore.SkiaSharpView.csproj
@@ -3,15 +3,15 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <LangVersion>11.0</LangVersion>
-    
-    <TargetFrameworks>netstandard2.0;netcoreapp2.0;net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
+
+    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">
       $(TargetFrameworks);net6.0-windows10.0.19041;net462
     </TargetFrameworks>
 
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-ios'">14.2</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net8.0-ios'">14.2</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net8.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net8.0-android'">21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</TargetPlatformMinVersion>
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKCartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKCartesianChart.cs
@@ -75,6 +75,9 @@ public class SKCartesianChart : InMemorySkiaSharpChart, ICartesianChartView<Skia
         VisualElements = view.VisualElements;
     }
 
+    /// <inheritdoc cref="IChartView.ResetSeries">
+    public bool ResetSeries { get; set; }
+
     /// <inheritdoc cref="IChartView.DesignerMode" />
     public bool DesignerMode => false;
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKPieChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKPieChart.cs
@@ -73,6 +73,9 @@ public class SKPieChart : InMemorySkiaSharpChart, IPieChartView<SkiaSharpDrawing
         VisualElements = view.VisualElements;
     }
 
+    /// <inheritdoc cref="IChartView.ResetSeries">
+    public bool ResetSeries { get; set; }
+
     /// <inheritdoc cref="IChartView.DesignerMode" />
     public bool DesignerMode => false;
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKPolarChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKPolarChart.cs
@@ -75,6 +75,9 @@ public class SKPolarChart : InMemorySkiaSharpChart, IPolarChartView<SkiaSharpDra
         VisualElements = view.VisualElements;
     }
 
+    /// <inheritdoc cref="IChartView.ResetSeries">
+    public bool ResetSeries { get; set; }
+
     /// <inheritdoc cref="IChartView.DesignerMode" />
     public bool DesignerMode => false;
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/CartesianChart.xaml.cs
@@ -116,7 +116,7 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
         chartBehaviour.On(this);
     }
 
-    #region bindable properties 
+    #region bindable properties
 
     /// <summary>
     /// The sync context property.
@@ -386,7 +386,10 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
         BindableProperty.Create(
             nameof(VisualElementsPointerDownCommand), typeof(ICommand), typeof(CartesianChart), null);
 
-    #endregion
+    public static readonly BindableProperty ResetSeriesProperty =
+        BindableProperty.Create(nameof(ResetSeries), typeof(bool), typeof(CartesianChart), false);
+
+#endregion
 
     #region events
 
@@ -414,6 +417,12 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
 
     /// <inheritdoc cref="IChartView.DesignerMode" />
     bool IChartView.DesignerMode => false;
+
+    public bool ResetSeries
+    {
+        get => (bool)GetValue(ResetSeriesProperty);
+        set => SetValue(ResetSeriesProperty, value);
+    }
 
     /// <inheritdoc cref="IChartView.CoreChart" />
     public IChart CoreChart => _core ?? throw new Exception("Core not set yet.");

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/LiveChartsCore.SkiaSharpView.Maui.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/LiveChartsCore.SkiaSharpView.Maui.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-    <TargetFrameworks>net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
 	  <UseMaui>true</UseMaui>
 	  <SingleProject>true</SingleProject>
     <Nullable>enable</Nullable>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/PieChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/PieChart.xaml.cs
@@ -321,6 +321,9 @@ public partial class PieChart : ContentView, IPieChartView<SkiaSharpDrawingConte
         BindableProperty.Create(
             nameof(VisualElementsPointerDownCommand), typeof(ICommand), typeof(PieChart), null);
 
+    public static readonly BindableProperty ResetSeriesProperty =
+        BindableProperty.Create(nameof(ResetSeries), typeof(bool), typeof(PieChart), false);
+
     #endregion
 
     #region events
@@ -611,6 +614,13 @@ public partial class PieChart : ContentView, IPieChartView<SkiaSharpDrawingConte
     {
         get => (ICommand?)GetValue(VisualElementsPointerDownCommandProperty);
         set => SetValue(VisualElementsPointerDownCommandProperty, value);
+    }
+
+    /// <inheritdoc cref="IChartView.ResetSeries">
+    public bool ResetSeries
+    {
+        get => (bool)GetValue(ResetSeriesProperty);
+        set => SetValue(ResetSeriesProperty, value);
     }
 
     #endregion

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/PolarChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/PolarChart.xaml.cs
@@ -107,7 +107,7 @@ public partial class PolarChart : ContentView, IPolarChartView<SkiaSharpDrawingC
         chartBehaviour.On(this);
     }
 
-    #region bindable properties 
+    #region bindable properties
 
     /// <summary>
     /// The sync context property.
@@ -362,6 +362,9 @@ public partial class PolarChart : ContentView, IPolarChartView<SkiaSharpDrawingC
         BindableProperty.Create(
             nameof(VisualElementsPointerDownCommand), typeof(ICommand), typeof(PolarChart), null);
 
+    public static readonly BindableProperty ResetSeriesProperty =
+        BindableProperty.Create(nameof(ResetSeries), typeof(bool), typeof(PolarChart), false);
+
     #endregion
 
     #region events
@@ -390,6 +393,13 @@ public partial class PolarChart : ContentView, IPolarChartView<SkiaSharpDrawingC
 
     /// <inheritdoc cref="IChartView.DesignerMode" />
     bool IChartView.DesignerMode => false;
+
+    /// <inheritdoc cref="IChartView.ResetSeries">
+    public bool ResetSeries
+    {
+        get => (bool)GetValue(ResetSeriesProperty);
+        set => SetValue(ResetSeriesProperty, value);
+    }
 
     /// <inheritdoc cref="IChartView.CoreChart" />
     public IChart CoreChart => _core ?? throw new Exception("Core not set yet.");


### PR DESCRIPTION
* Added a ResetSeries property that when set to true, will cause the charts to redraw with a reset color list
* Upgrade to .NET 8